### PR TITLE
DEV-691: enable auto-opening terms and privacy modals via URL parameters

### DIFF
--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -3,6 +3,10 @@
     const modal = document.getElementById('myModal');
     const overlay = document.querySelector('.modal__overlay');
 
+    // Check URL parameters to auto-open modals
+    const urlParams = new URLSearchParams(window.location.search);
+    const modalParam = urlParams.get('modal');
+
     if (openModalButton && closeModalButton && modal && overlay) {
         openModalButton.addEventListener('click', () => {
             modal.classList.add('modal--active');
@@ -30,6 +34,19 @@
     const privacyModal = document.getElementById('privacyModal');
     const privacyOverlay = document.querySelector('.privacy__overlay');
     const openPrivacyButtons = document.querySelectorAll('.modal--privacy');
+
+    // Auto-open modals based on URL parameter
+    if (modalParam === 'terms' && modal && overlay) {
+        modal.classList.add('modal--active');
+        document.body.style.overflow = 'hidden';
+        overlay.style.opacity = '1';
+        overlay.style.visibility = 'visible';
+    } else if (modalParam === 'privacy' && privacyModal && privacyOverlay) {
+        privacyModal.classList.add('privacy--active');
+        document.body.style.overflow = 'hidden';
+        privacyOverlay.style.opacity = '1';
+        privacyOverlay.style.visibility = 'visible';
+    }
 
     openPrivacyButtons.forEach(button => {
         button.addEventListener('click', () => {


### PR DESCRIPTION
This PR introduces support for automatically opening the Terms and Conditions or Privacy Policy modals based on URL parameters.

Changes
- Added URL parameter parsing in modal.js using URLSearchParams.
- Supported parameters:
a. ?modal=terms → auto-opens the Terms and Conditions modal.
b. ?modal=privacy → auto-opens the Privacy Policy modal.
- Ensures correct overlay visibility and disables page scroll when modal is active.

Purpose
This allows the application to provide direct access from the login page to Terms and Conditions or Privacy Policy.