### PR TITLE
feat(modal): add auto-open functionality based on URL parameters

### DIFF
--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -1,7 +1,12 @@
+document.addEventListener('DOMContentLoaded', function() {
     const openModalButton = document.getElementById('openModal');
     const closeModalButton = document.getElementById('closeModal');
     const modal = document.getElementById('myModal');
     const overlay = document.querySelector('.modal__overlay');
+
+    // Check URL parameters to auto-open modals
+    const urlParams = new URLSearchParams(window.location.search);
+    const modalParam = urlParams.get('modal');
 
     if (openModalButton && closeModalButton && modal && overlay) {
         openModalButton.addEventListener('click', () => {
@@ -31,6 +36,19 @@
     const privacyOverlay = document.querySelector('.privacy__overlay');
     const openPrivacyButtons = document.querySelectorAll('.modal--privacy');
 
+    // Auto-open modals based on URL parameter
+    if (modalParam === 'terms' && modal && overlay) {
+        modal.classList.add('modal--active');
+        document.body.style.overflow = 'hidden';
+        overlay.style.opacity = '1';
+        overlay.style.visibility = 'visible';
+    } else if (modalParam === 'privacy' && privacyModal && privacyOverlay) {
+        privacyModal.classList.add('privacy--active');
+        document.body.style.overflow = 'hidden';
+        privacyOverlay.style.opacity = '1';
+        privacyOverlay.style.visibility = 'visible';
+    }
+
     openPrivacyButtons.forEach(button => {
         button.addEventListener('click', () => {
             privacyModal.classList.add('privacy--active');
@@ -57,6 +75,7 @@
             privacyOverlay.style.visibility = 'hidden';
         });
     })
+});
 
     // Expand image
   function updateSlider() {


### PR DESCRIPTION
Description:
This PR enhances the modal behavior by allowing modals to auto-open based on URL parameters.

Key changes:

- Wrapped modal logic inside DOMContentLoaded to ensure DOM elements are available.
- Added support for ?modal=terms → auto-opens the Terms modal.
- Added support for ?modal=privacy → auto-opens the Privacy modal.
- Ensured overlay and body scroll handling are consistent with manual modal actions.

Files updated:

assets/js/modal.js